### PR TITLE
SNOW-776340 Ignore Platform/BOM dependencies in Gradle Plugin

### DIFF
--- a/src/main/java/com/snowflake/core/Snowflake.java
+++ b/src/main/java/com/snowflake/core/Snowflake.java
@@ -1,5 +1,6 @@
 package com.snowflake.core;
 
+import java.io.File;
 import java.sql.SQLException;
 import java.util.*;
 import net.snowflake.client.jdbc.SnowflakeConnectionV1;
@@ -15,6 +16,10 @@ public class Snowflake {
   private String artifactDirOnStage = "libs";
   private String dependencyDirOnStage = "dependency";
   private SnowflakeConnectionV1 conn;
+  // A set of dependencies which did not resolve to JAR files and are therefore skipped on upload
+  // These are usually Gradle platform dependencies or Maven Bill-Of-Materials (BOM) which do not
+  // need to be uploaded
+  private Set<String> skippedDependencies = new HashSet<>();
 
   /**
    * Create a snowflake object representing a session with a logger
@@ -47,10 +52,28 @@ public class Snowflake {
       String dependencyFile = entry.getKey();
       String stagePath = entry.getValue();
       sfLogger.info("Uploading " + dependencyFile);
-      uploadFiles(
-          String.format("%s/%s", localFilePath, dependencyFile), stageName, stagePath, false);
+      String dependencyFilePath = String.format("%s/%s", localFilePath, dependencyFile);
+      uploadDependencyIfExists(dependencyFilePath, stageName, stagePath, dependencyFile);
     }
     sfLogger.info("Dependency JARs uploaded!");
+  }
+
+  // Split up uploadDependencies function to avoid mocking files in tests
+  public void uploadDependencyIfExists(
+      String dependencyFilePath, String stageName, String stagePath, String dependencyFile)
+      throws SQLException {
+    if (new File(dependencyFilePath).isFile()) {
+      uploadFiles(dependencyFilePath, stageName, stagePath, false);
+    } else {
+      // If a jar file for the dependency is not found, skip it
+      // These are usually Gradle platform dependencies or Maven Bill-Of-Materials (BOM) which do
+      // not need to be uploaded
+      skippedDependencies.add(dependencyFile);
+      sfLogger.info(
+          String.format(
+              "Dependency jar not found at %s. This is not a problem if the dependency was a platform/bill-of-materials dependency",
+              dependencyFilePath));
+    }
   }
 
   public void uploadFiles(
@@ -112,7 +135,9 @@ public class Snowflake {
     for (Map.Entry<String, String> entry : depsToStagePath.entrySet()) {
       String dependencyFile = entry.getKey();
       String stagePath = entry.getValue();
-      imports.add(stagePath + "/" + dependencyFile);
+      if (!skippedDependencies.contains(dependencyFile)) {
+        imports.add(stagePath + "/" + dependencyFile);
+      }
     }
     List<String> importPaths = new ArrayList<>();
     for (String s : imports) {

--- a/src/test/java/com/snowflake/core/SnowflakeTest.java
+++ b/src/test/java/com/snowflake/core/SnowflakeTest.java
@@ -42,12 +42,46 @@ public class SnowflakeTest {
 
   @Test
   public void testUploadDependencies() throws SQLException {
-    Snowflake sf = new Snowflake(log::info, conn);
+    Snowflake sf = spy(new Snowflake(log::info, conn));
+    doNothing()
+        .when(sf)
+        .uploadDependencyIfExists(anyString(), anyString(), anyString(), anyString());
+
     Map<String, String> depsToStagePath = new HashMap<>();
     depsToStagePath.put("gson-2.10.jar", "com/google/gson/2.10/gson-2.10.jar");
     depsToStagePath.put("gson-2.11.jar", "com/google/gson/2.11/gson-2.11.jar");
     depsToStagePath.put("dep.jar", "com/google/dep/1.2.3/dep-1.2.3.jar");
     sf.uploadDependencies("target/dependency", "mystage", depsToStagePath);
+
+    verify(sf)
+        .uploadDependencyIfExists(
+            "target/dependency/dep.jar",
+            "mystage",
+            "com/google/dep/1.2.3/dep-1.2.3.jar",
+            "dep.jar");
+    verify(sf)
+        .uploadDependencyIfExists(
+            "target/dependency/gson-2.10.jar",
+            "mystage",
+            "com/google/gson/2.10/gson-2.10.jar",
+            "gson-2.10.jar");
+    verify(sf)
+        .uploadDependencyIfExists(
+            "target/dependency/gson-2.11.jar",
+            "mystage",
+            "com/google/gson/2.11/gson-2.11.jar",
+            "gson-2.11.jar");
+  }
+
+  @Test
+  public void testUploadFiles() throws SQLException {
+    Snowflake sf = new Snowflake(log::info, conn);
+    sf.uploadFiles(
+        "target/dependency/dep.jar", "mystage", "com/google/dep/1.2.3/dep-1.2.3.jar", false);
+    sf.uploadFiles(
+        "target/dependency/gson-2.10.jar", "mystage", "com/google/gson/2.10/gson-2.10.jar", false);
+    sf.uploadFiles(
+        "target/dependency/gson-2.11.jar", "mystage", "com/google/gson/2.11/gson-2.11.jar", false);
     verify(statement)
         .execute(
             "PUT file://target/dependency/dep.jar"


### PR DESCRIPTION
# Changes

Don't attempt to upload or import platform/BOM dependencies, which will result in "jar not found" error (since these dependencies do resolve to a JAR).

A [Gradle platform dependency](https://docs.gradle.org/current/userguide/platforms.html#sub:using-platform-to-control-transitive-deps) can be declared by client projects to constrain the version numbers of its direct and transitive dependencies.

A client project can also depend on a [Maven Bill of Materials (BOM)](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html) to constrain the version numbers of its direct and transitive dependencies. Used by a client project [like this](https://docs.gradle.org/current/userguide/platforms.html#sub:bom_import).

# How
Skips the upload and import of dependencies that cannot be resolved to a JAR file. 

In my testing with different dependencies on a client project, only BOM/platform dependencies could not be resolved to a JAR file by the Snowflake plugin. i.e. All other necessary dependencies that are not BOM/platform dependencies will be properly uploaded and imported like before.

# Impact

This fixes the support for procedures on Gradle plugin. Previously, the [jackson-bom](https://mvnrepository.com/artifact/com.fasterxml.jackson/jackson-bom) dependency of Snowpark would result in a "jackson-bom.jar" not found error for our plugin (and Snowpark is a necessary dependency for all procedures).

# Maven

This issue does not exist for the Snowflake Maven plugin because the "list dependencies" goal provided by Maven doesn't explicitly list BOMs as dependencies so our plugin is not exposed to any BOMs.
