### PR TITLE
SNOW-769520 require snowflake URL and ignore ACCOUNT

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,7 @@ Create a properties file `profile.properties` in the root of the project
 with information to establish a JDBC connection to your Snowflake account:
 ```properties
 # profile.properties
-# Supply either one of the URL or ACCOUNT properties
 URL=https://MY_ACCOUNT_NAME.snowflakecomputing.com:443
-ACCOUNT=MY_ACCOUNT_NAME
 USER=username
 PASSWORD=password
 # Optional properties:
@@ -168,9 +166,7 @@ Simply expose the following environment variables from the secrets provider:
     <version>0.1.0-SNAPSHOT</version>
     <configuration>
         <auth>
-            <!-- Supply either one of the URL or ACCOUNT properties -->
             <url>${env.MY_URL}</url>
-            <account>${env.MY_ACCOUNT}</account>
             <user>${env.MY_USER}</user>
             <password>${env.MY_PASSWORD}</password>
             <!-- optional auth configuration -->  
@@ -186,7 +182,7 @@ Simply expose the following environment variables from the secrets provider:
 Auth parameters can optionally be provided as arguments when running the plugin from the CLI.
 Values from CLI arguments will override any values set in the properties file or POM:
 ```
-mvn snowflake-udx:deploy -Ddeploy.auth.user=”username” -Ddeploy.auth.password=”password” -Ddeploy.auth.url=”myaccount.snowflakecomputing.com” -Ddeploy.auth.account=”myaccount” -Ddeploy.auth.role=”myrole” -Ddeploy.auth.db=”mydb” -Ddeploy.auth.schema=”myschema”
+mvn snowflake-udx:deploy -Ddeploy.auth.user=”username” -Ddeploy.auth.password=”password” -Ddeploy.auth.url=”myaccount.snowflakecomputing.com” -Ddeploy.auth.role=”myrole” -Ddeploy.auth.db=”mydb” -Ddeploy.auth.schema=”myschema”
 ```
 
 A single function or procedure can also be specified through command line arguments. 

--- a/src/main/java/com/snowflake/core/SnowflakeBuilder.java
+++ b/src/main/java/com/snowflake/core/SnowflakeBuilder.java
@@ -21,9 +21,7 @@ public class SnowflakeBuilder {
 
   public SnowflakeBuilder config(String key, String val) {
     key = key.toLowerCase();
-    if (key.equals("account")) {
-      url = formatUrl(String.format("%s.snowflakecomputing.com", val));
-    } else if (key.equals("url")) {
+    if (key.equals("url")) {
       url = formatUrl(val);
     } else {
       options.put(key, val);

--- a/src/main/java/com/snowflake/snowflake_maven_plugin/DeployGoal.java
+++ b/src/main/java/com/snowflake/snowflake_maven_plugin/DeployGoal.java
@@ -97,9 +97,6 @@ public class DeployGoal extends AbstractMojo {
   @Parameter(property = "deploy.auth.url")
   private String auth_url;
 
-  @Parameter(property = "deploy.auth.account")
-  private String auth_account;
-
   @Parameter(property = "deploy.auth.user")
   private String auth_user;
 
@@ -238,7 +235,6 @@ public class DeployGoal extends AbstractMojo {
     // Read CLI auth config
     Map<String, String> authCliParams = new HashMap<>();
     authCliParams.put("url", auth_url);
-    authCliParams.put("account", auth_account);
     authCliParams.put("user", auth_user);
     authCliParams.put("password", auth_password);
     authCliParams.put("role", auth_role);

--- a/src/test/java/com/snowflake/core/SnowflakeBuilderTest.java
+++ b/src/test/java/com/snowflake/core/SnowflakeBuilderTest.java
@@ -19,8 +19,6 @@ public class SnowflakeBuilderTest {
     sb.config("NAME", "otherName");
     assertThat(sb.options, hasEntry("name", "otherName"));
     // config should set url and account with formatting
-    sb.config("account", "myaccount");
-    assertEquals(sb.url, "jdbc:snowflake://myaccount.snowflakecomputing.com:443");
     String[] urls =
         new String[] {
           "myaccount.snowflakecomputing.com",


### PR DESCRIPTION
# Changes
We should always require URL, and since URL contains the account name, then account is unnecessary (should be ignored).

URL is required since all deployments have dedicated sub-domain name (For example `.snowflakecomputing.com` is only the domain name for US-West-2 (prod1) deployment). So if user only provides account name, we don't know which deployment they are using.

# How
- Ignore the ACCOUNT parameter in CLI, properties file, and POM
- Updated tests, README