### PR TITLE
SNOW-794853 snowflakeDeploy task depends on build

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,8 +343,9 @@ snowflake {
 After configuration, run the following to publish your functions and procedures:
 
 ```shell
-gradle clean build snowflakeDeploy
+gradle snowflakeDeploy
 ```
+The `snowflakeDeploy` task will trigger the `build` task if `build` is not up to date.
 
 ### Usage in CI pipelines
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ gradlePlugin {
 	plugins {
 		snowflakeGradlePlugin {
 			id = 'com.snowflake.snowflake-gradle-plugin'
-			implementationClass = 'com.snowflake.snowflake_gradle_plugin.SnowflakePlugin'
+			implementationClass = 'com.snowflake.plugins.udf.gradle.SnowflakePlugin'
 		}
 	}
 }

--- a/src/main/java/com/snowflake/plugins/udf/gradle/SnowflakePlugin.java
+++ b/src/main/java/com/snowflake/plugins/udf/gradle/SnowflakePlugin.java
@@ -35,6 +35,7 @@ public class SnowflakePlugin implements Plugin<Project> {
             SnowflakeDeployTask.class,
             tasks.getByName("listDependenciesTask").getOutputs().getFiles().iterator().next())
         .dependsOn("copyDependenciesTask")
-        .dependsOn("listDependenciesTask");
+        .dependsOn("listDependenciesTask")
+        .dependsOn("build");
   }
 }


### PR DESCRIPTION
# What
Currently, the `snowflakeDeploy` task does not build the client project and will throw an error if the user has not run `gradle build` prior to the `snowflakeDeploy` task.

The `snowflakeDeploy` task will build the project by triggering `gradle build` if the build task is not "up to date" (i.e. if the user has modified the source code and hasn't triggered `gradle build`)

This means that the user can run 
```
gradle snowflakeDeploy
```
Instead of 
```
gradle build snowflakeDeploy
```

# Why
This follows a convention that may be expected by users:
- Other Gradle `deploy` tasks such as [Azure Webapp Deploy](https://learn.microsoft.com/en-us/azure/app-service/configure-language-java?pivots=platform-linux#gradle) will automatically build the JAR
- The [gradle-snowflake](https://github.com/stewartbryson/gradle-snowflake) plugin builds a fat jar for the user

# Counterexample
The Openshift Gradle Plugin requires users to build artifacts before running `ocApply` which deploys the application