### PR TITLE
Update 'implementationClass' to new location

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ gradlePlugin {
 	plugins {
 		snowflakeGradlePlugin {
 			id = 'com.snowflake.snowflake-gradle-plugin'
-			implementationClass = 'com.snowflake.snowflake_gradle_plugin.SnowflakePlugin'
+			implementationClass = 'com.snowflake.plugins.udf.gradle.SnowflakePlugin'
 		}
 	}
 }


### PR DESCRIPTION
This may have been missed as part of refactors in SNOW-791036 / #24 

This change fixes local build warning (this is an error in actual plugin use):

```
Task :jar
:jar: A valid plugin descriptor was found for com.snowflake.snowflake-gradle-plugin.properties but the implementation class com.snowflake.snowflake_gradle_plugin.SnowflakePlugin was not found in the jar.
```