### PR TITLE
SNOW-800801 Ignore "@" in stage name and refactor Snowflake class

### DIFF
--- a/snowflake-plugins-core/src/main/java/com/snowflake/plugins/udf/core/SnowflakeBuilder.java
+++ b/snowflake-plugins-core/src/main/java/com/snowflake/plugins/udf/core/SnowflakeBuilder.java
@@ -12,6 +12,12 @@ import net.snowflake.client.jdbc.SnowflakeConnectionV1;
 public class SnowflakeBuilder {
   public Map<String, String> options = new HashMap<>();
   public String url;
+  // The name of the stage used for uploaded files
+  private String stageName;
+  // The name of the project artifact file
+  private String artifactFileName;
+  // A map of each dependency to its path on the stage
+  private Map<String, String> depsToStagePaths;
   // Logger object passed from Maven/Gradle plugin
   private SnowflakeLogger sfLogger;
 
@@ -47,6 +53,21 @@ public class SnowflakeBuilder {
     return this;
   }
 
+  public SnowflakeBuilder stageName(String stageName) {
+    this.stageName = stageName;
+    return this;
+  }
+
+  public SnowflakeBuilder artifactFileName(String artifactFileName) {
+    this.artifactFileName = artifactFileName;
+    return this;
+  }
+
+  public SnowflakeBuilder depsToStagePaths(Map<String, String> depsToStagePaths) {
+    this.depsToStagePaths = depsToStagePaths;
+    return this;
+  }
+
   // Creates the Snowflake connection object. Will throw exceptions for invalid connection data such
   // as missing/incorrect url, user, password.
   public Snowflake create() throws SQLException {
@@ -58,7 +79,7 @@ public class SnowflakeBuilder {
     sfLogger.info("Creating connection to snowflake at url: " + url);
     SnowflakeConnectionV1 conn = new SnowflakeConnectionV1(url, prop);
     sfLogger.info("Snowflake Session established!");
-    return new Snowflake(sfLogger, conn);
+    return new Snowflake(sfLogger, conn, stageName, artifactFileName, depsToStagePaths);
   }
 
   // Format the user provided url to match JDBC Connection url

--- a/snowflake-plugins-core/src/test/java/com/snowflake/plugins/udf/core/SnowflakeTest.java
+++ b/snowflake-plugins-core/src/test/java/com/snowflake/plugins/udf/core/SnowflakeTest.java
@@ -26,14 +26,16 @@ public class SnowflakeTest {
 
   @Test
   public void testUploadArtifact() throws SQLException {
-    Snowflake sf = new Snowflake(log::info, conn);
-    sf.uploadArtifact("myproject.jar", "mvn_stage");
-    sf.uploadArtifact(" myproject.jar  ", " mvn_stage  ");
+    Snowflake sf = new Snowflake(log::info, conn, "mvn_stage", "myproject.jar", new HashMap<>());
+    sf.uploadArtifact("hi/myproject.jar");
+    sf = new Snowflake(log::info, conn, " mvn_stage  ", "myproject.jar", new HashMap<>());
+    sf.uploadArtifact("hi/myproject.jar");
     verify(statement, times(2))
         .execute(
-            "PUT file://myproject.jar @mvn_stage/libs OVERWRITE = true AUTO_COMPRESS ="
+            "PUT file://hi/myproject.jar @mvn_stage/libs OVERWRITE = true AUTO_COMPRESS ="
                 + " FALSE PARALLEL = 4");
-    sf.uploadArtifact("'file:///tmp/load data'", "@mvn_stage");
+    sf = new Snowflake(log::info, conn, "@mvn_stage", "tmp/load data", new HashMap<>());
+    sf.uploadArtifact("'file:///tmp/load data'");
     verify(statement)
         .execute(
             "PUT 'file:///tmp/load data' @mvn_stage/libs OVERWRITE = true"
@@ -42,46 +44,35 @@ public class SnowflakeTest {
 
   @Test
   public void testUploadDependencies() throws SQLException {
-    Snowflake sf = spy(new Snowflake(log::info, conn));
-    doNothing()
-        .when(sf)
-        .uploadDependencyIfExists(anyString(), anyString(), anyString(), anyString());
-
     Map<String, String> depsToStagePath = new HashMap<>();
     depsToStagePath.put("gson-2.10.jar", "com/google/gson/2.10/gson-2.10.jar");
     depsToStagePath.put("gson-2.11.jar", "com/google/gson/2.11/gson-2.11.jar");
     depsToStagePath.put("dep.jar", "com/google/dep/1.2.3/dep-1.2.3.jar");
-    sf.uploadDependencies("target/dependency", "mystage", depsToStagePath);
+    Snowflake sf = spy(new Snowflake(log::info, conn, "stage", "artifact", depsToStagePath));
+    doNothing().when(sf).uploadDependencyIfExists(anyString(), anyString(), anyString());
+    sf.uploadDependencies("target/dependency");
 
     verify(sf)
         .uploadDependencyIfExists(
-            "target/dependency/dep.jar",
-            "mystage",
-            "com/google/dep/1.2.3/dep-1.2.3.jar",
-            "dep.jar");
+            "target/dependency/dep.jar", "com/google/dep/1.2.3/dep-1.2.3.jar", "dep.jar");
     verify(sf)
         .uploadDependencyIfExists(
             "target/dependency/gson-2.10.jar",
-            "mystage",
             "com/google/gson/2.10/gson-2.10.jar",
             "gson-2.10.jar");
     verify(sf)
         .uploadDependencyIfExists(
             "target/dependency/gson-2.11.jar",
-            "mystage",
             "com/google/gson/2.11/gson-2.11.jar",
             "gson-2.11.jar");
   }
 
   @Test
   public void testUploadFiles() throws SQLException {
-    Snowflake sf = new Snowflake(log::info, conn);
-    sf.uploadFiles(
-        "target/dependency/dep.jar", "mystage", "com/google/dep/1.2.3/dep-1.2.3.jar", false);
-    sf.uploadFiles(
-        "target/dependency/gson-2.10.jar", "mystage", "com/google/gson/2.10/gson-2.10.jar", false);
-    sf.uploadFiles(
-        "target/dependency/gson-2.11.jar", "mystage", "com/google/gson/2.11/gson-2.11.jar", false);
+    Snowflake sf = new Snowflake(log::info, conn, "mystage", "artifact", new HashMap<>());
+    sf.uploadFiles("target/dependency/dep.jar", "com/google/dep/1.2.3/dep-1.2.3.jar", false);
+    sf.uploadFiles("target/dependency/gson-2.10.jar", "com/google/gson/2.10/gson-2.10.jar", false);
+    sf.uploadFiles("target/dependency/gson-2.11.jar", "com/google/gson/2.11/gson-2.11.jar", false);
     verify(statement)
         .execute(
             "PUT file://target/dependency/dep.jar"
@@ -101,12 +92,13 @@ public class SnowflakeTest {
 
   @Test
   public void testGetImportString() throws SQLException {
-    Snowflake sf = new Snowflake(log::info, conn);
     Map<String, String> depsToStagePath = new HashMap<>();
     depsToStagePath.put("gson-2.10.jar", "com/google/gson/2.10/gson-2.10.jar");
     depsToStagePath.put("gson-2.11.jar", "com/google/gson/2.11/gson-2.11.jar");
     depsToStagePath.put("dep.jar", "com/google/dep/1.2.3/dep-1.2.3.jar");
-    String importString = sf.getImportString("project.jar", "mystage", depsToStagePath);
+    Snowflake sf = new Snowflake(log::info, conn, "mystage", "project.jar", depsToStagePath);
+
+    String importString = sf.getImportString();
     assertEquals(
         "'@mystage/libs/project.jar',"
             + " '@mystage/com/google/dep/1.2.3/dep-1.2.3.jar/dep.jar',"


### PR DESCRIPTION
# What
Implements #4 by ignoring "@" in stage name 

# How
- Normalize stage name in `Snowflake` core constructor
- Refactor: Extract`stage`, `artifactFileName` and `DependencyToStagePaths map` to object properties instead of method parameters to shrink function signatures